### PR TITLE
fix minimum version dependancies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require-dev": {
-        "atoum/atoum": "<3.0"
+        "atoum/atoum": ">=1.0,<3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Avoir getting this error when installing the extension
with the minimum authorized dependancies :

```
PHP Fatal error:  Call to undefined method mageekguy\atoum\runner::addExtension() in /home/agallou/Projets/deprecated-extension/.atoum.php on line 7
```
