### PR TITLE
add missing travis php version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 php:
+  - 5.3
   - 5.4
   - 5.5
   - 5.6


### PR DESCRIPTION
Like that we launch tests on the same tested PHP versions than atoum.
