### PR TITLE
split the deprecated output from the outputs output

### DIFF
--- a/classes/extension.php
+++ b/classes/extension.php
@@ -9,8 +9,14 @@ use mageekguy\atoum\test;
 
 class extension implements atoum\extension
 {
+	/**
+	 * @var rescorer
+	 */
 	protected $rescorer;
 
+	/**
+	 * @param atoum\configurator|null $configurator
+	 */
 	public function __construct(atoum\configurator $configurator = null)
 	{
 		if ($configurator)
@@ -30,6 +36,11 @@ class extension implements atoum\extension
 		$this->rescorer = new rescorer();
 	}
 
+	/**
+	 * @param runner $runner
+	 *
+	 * @return $this
+	 */
 	public function setRunner(runner $runner)
 	{
 		return $this;
@@ -54,5 +65,12 @@ class extension implements atoum\extension
 		if ($event == atoum\test::beforeTearDown && $observable instanceof \mageekguy\atoum\test) {
 			$this->rescorer->rescore($observable->getScore());
 		}
+
+		if ($event == atoum\runner::runStart && $observable instanceof \mageekguy\atoum\runner) {
+			$outputHandler = new outputHandler();
+			$outputHandler->handle($observable, $this->rescorer);
+		}
 	}
+
+
 }

--- a/classes/outputHandler.php
+++ b/classes/outputHandler.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace mageekguy\atoum\deprecated;
+
+use mageekguy\atoum\cli\colorizer;
+use mageekguy\atoum\cli\prompt;
+use mageekguy\atoum\deprecated\report\fields\runner\deprecations\cli;
+use mageekguy\atoum\runner;
+
+class outputHandler
+{
+	/**
+	 * @param runner $runner
+	 * @param rescorer $rescorer
+	 */
+	public function handle(runner $runner, rescorer $rescorer)
+	{
+		$cliReport = $this->getCliReport($runner);
+
+		if (null === $cliReport) {
+			return;
+		}
+
+		$defaultColorizer = new colorizer('1;36');
+		$firstLevelPrompt = new prompt('> ');
+		$secondLevelPrompt = new prompt('=> ', $defaultColorizer);
+
+		$runnerOutputsField = new cli($rescorer);
+		$runnerOutputsField->setTitlePrompt($firstLevelPrompt);
+		$runnerOutputsField->setTitleColorizer($defaultColorizer);
+		$runnerOutputsField->setMethodPrompt($secondLevelPrompt);
+
+		$cliReport->addField($runnerOutputsField);
+	}
+
+	/**
+	 * @param runner $runner
+	 *
+	 * @return atoum\reports\realtime\cli|null
+	 */
+	protected function getCliReport(runner $runner)
+	{
+		$cliReport = null;
+
+		foreach ($runner->getReports() as $report) {
+			if ($report instanceof \mageekguy\atoum\reports\realtime\cli) {
+				$cliReport = $report;
+			}
+		}
+
+		return $cliReport;
+	}
+}

--- a/classes/report/fields/runner/deprecations/cli.php
+++ b/classes/report/fields/runner/deprecations/cli.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace mageekguy\atoum\deprecated\report\fields\runner\deprecations;
+
+use
+	mageekguy\atoum,
+	mageekguy\atoum\locale,
+	mageekguy\atoum\cli\prompt,
+	mageekguy\atoum\cli\colorizer,
+	mageekguy\atoum\report\fields\runner\outputs
+;
+
+class cli extends outputs
+{
+	protected $titlePrompt = null;
+	protected $titleColorizer = null;
+	protected $methodPrompt = null;
+	protected $methodColorizer = null;
+	protected $outputPrompt = null;
+	protected $outputColorizer = null;
+
+	protected $rescorer;
+
+	public function __construct(atoum\deprecated\rescorer $rescorer)
+	{
+		parent::__construct();
+
+		$this
+			->setTitlePrompt()
+			->setTitleColorizer()
+			->setMethodPrompt()
+			->setMethodColorizer()
+			->setOutputPrompt()
+			->setOutputColorizer()
+		;
+
+		$this->rescorer = $rescorer;
+	}
+
+	public function __toString()
+	{
+		$string = '';
+
+		if ($this->runner !== null)
+		{
+			$outputs = $this->rescorer->getErrors();
+
+			$sizeOfOutputs = sizeof($outputs);
+
+			if ($sizeOfOutputs > 0)
+			{
+				$string .=
+					$this->titlePrompt .
+					sprintf(
+						$this->locale->_('%s:'),
+						$this->titleColorizer->colorize(sprintf($this->locale->__('There is %d depreciation notice', 'There are %d depreciations notices', $sizeOfOutputs), $sizeOfOutputs))
+					) .
+					PHP_EOL
+				;
+
+				foreach ($outputs as $output)
+				{
+					$string .= $this->methodPrompt . sprintf('%s:', $this->methodColorizer->colorize(sprintf($this->locale->_('In %s::%s()'), $output['class'], $output['method']))) . PHP_EOL;
+
+					foreach (explode(PHP_EOL, rtrim($output['message'])) as $line)
+					{
+						$string .= $this->outputPrompt . $this->outputColorizer->colorize($line) . PHP_EOL;
+					}
+				}
+			}
+		}
+
+		return $string;
+	}
+
+	public function setTitlePrompt(prompt $prompt = null)
+	{
+		$this->titlePrompt = $prompt ?: new prompt();
+
+		return $this;
+	}
+
+	public function getTitlePrompt()
+	{
+		return $this->titlePrompt;
+	}
+
+	public function setTitleColorizer(colorizer $colorizer = null)
+	{
+		$this->titleColorizer = $colorizer ?: new colorizer();
+
+		return $this;
+	}
+
+	public function getTitleColorizer()
+	{
+		return $this->titleColorizer;
+	}
+
+	public function setMethodPrompt(prompt $prompt = null)
+	{
+		$this->methodPrompt = $prompt ?: new prompt();
+
+		return $this;
+	}
+
+	public function getMethodPrompt()
+	{
+		return $this->methodPrompt;
+	}
+
+	public function setMethodColorizer(colorizer $colorizer = null)
+	{
+		$this->methodColorizer = $colorizer ?: new colorizer();
+
+		return $this;
+	}
+
+	public function getMethodColorizer()
+	{
+		return $this->methodColorizer;
+	}
+
+	public function setOutputPrompt(prompt $prompt = null)
+	{
+		$this->outputPrompt = $prompt ?: new prompt();
+
+		return $this;
+	}
+
+	public function getOutputPrompt()
+	{
+		return $this->outputPrompt;
+	}
+
+	public function setOutputColorizer(colorizer $colorizer = null)
+	{
+		$this->outputColorizer = $colorizer ?: new colorizer();
+
+		return $this;
+	}
+
+	public function getOutputColorizer()
+	{
+		return $this->outputColorizer;
+	}
+}

--- a/classes/rescorer.php
+++ b/classes/rescorer.php
@@ -4,6 +4,9 @@ namespace mageekguy\atoum\deprecated;
 
 class rescorer
 {
+
+	protected $errors = array();
+
 	/**
 	 * @param \mageekguy\atoum\test\score $score
 	 *
@@ -17,9 +20,15 @@ class rescorer
 			}
 			$score->deleteError($key);
 
-			$score->addOutput($error['file'], $error['class'], $error['method'], $error["message"]);
+			$this->errors[] = $error;
 		}
+	}
 
-		return $score;
+	/**
+	 * @return array
+	 */
+	public function getErrors()
+	{
+		return $this->errors;
 	}
 }

--- a/tests/units/classes/rescorer.php
+++ b/tests/units/classes/rescorer.php
@@ -51,21 +51,16 @@ class rescorer extends atoum\test
 		$this
 			->given($testedClass = new testedClass)
 				->and($score)
-			->if($testedClass->rescore($score))
+			->if($errors = $testedClass->rescore($score))
 			->then
 				->array($score->getErrors())
 					->isEmpty()
 				->array($score->getFailAssertions())
 					->hasSize(1)
-				->array($score->getOutputs())
+				->array($testedClass->getErrors())
 					->hasSize(1)
 					->array[0]
-						->isEquaLTo(array(
-							'class' => 'titi\tests\units\foo',
-							'method' => 'testBar',
-							'value' => 'Deprecated since 2.0. use ->bar instead',
-						))
-
+						->isEquaLTo($error)
 		;
 	}
 }


### PR DESCRIPTION
The list of deprecated notices were inside the list of outputs.

The output looked like this:

```
> There are 4 outputs:
=> In fooNs\tests\units\foo::testFoo():
toto
=> In fooNs\tests\units\foo::testFoo2():
toto
=> In fooNs\tests\units\foo::testFoo():
Deprecated since 2.0. use ->bar instead
=> In fooNs\tests\units\foo::testFoo2():
Deprecated since 2.0. use ->bar instead
```

The output now looks like this:

```
Success (1 test, 2/2 methods, 0 void method, 0 skipped method, 4 assertions)!
> There are 2 outputs:
=> In fooNs\tests\units\foo::testFoo():
toto
=> In fooNs\tests\units\foo::testFoo2():
toto
> There are 2 depreciations notices:
=> In fooNs\tests\units\foo::testFoo():
Deprecated since 2.0. use ->bar instead
=> In fooNs\tests\units\foo::testFoo2():
Deprecated since 2.0. use ->bar instead
```
